### PR TITLE
check_strings must not ignore strings in SetMessage()

### DIFF
--- a/cmds/extract_strings.go
+++ b/cmds/extract_strings.go
@@ -640,6 +640,15 @@ func (es *extractStrings) processEnforcedFunc(expr ast.Expr, fset *token.FileSet
 					for _, arg := range call.Args {
 						if b, ok := arg.(*ast.BasicLit); ok {
 							es.processBasicLit(b, arg, fset, true)
+							return
+						}
+						// in case a string argument is wrapped by fmt.Sprintf or similar funcs
+						if innerCall, ok := arg.(*ast.CallExpr); ok {
+							for _, innerArg := range innerCall.Args {
+								if innerB, ok := innerArg.(*ast.BasicLit); ok {
+									es.processBasicLit(innerB, innerArg, fset, true)
+								}
+							}
 						}
 					}
 				}

--- a/cmds/extract_strings.go
+++ b/cmds/extract_strings.go
@@ -538,7 +538,7 @@ func (es *extractStrings) processBasicLit(basicLit *ast.BasicLit, n ast.Node, fs
 					// There may be an edge case when a user calls .SetCode("text") after SetMessage but
 					// the easy fix would be to use a const or re-order the call
 					funcIndex := strings.Index(line, "SetMessage(")
-					if funcIndex == -1 || int(n.Pos()) < strings.Index(line, "SetMessage(") {
+					if funcIndex == -1 || fset.Position(n.Pos()).Column < funcIndex {
 						return
 					}
 				}
@@ -558,15 +558,9 @@ func (es *extractStrings) processBasicLit(basicLit *ast.BasicLit, n ast.Node, fs
 	}
 }
 
-// Could be LRU if memory usage is a concern
-var readLineCache = map[string]string{}
-
 func readLine(fn string, n int) (string, error) {
 	if n < 1 {
 		return "", fmt.Errorf("invalid request: line %d", n)
-	}
-	if v, ok := readLineCache[fn+string(n)]; ok {
-		return v, nil
 	}
 	f, err := os.Open(fn)
 	if err != nil {
@@ -594,7 +588,6 @@ func readLine(fn string, n int) (string, error) {
 	if line == "" {
 		return "", fmt.Errorf("line %d empty", n)
 	}
-	readLineCache[fn+string(n)] = line
 	return line, nil
 }
 

--- a/cmds/extract_strings.go
+++ b/cmds/extract_strings.go
@@ -492,6 +492,16 @@ func (es *extractStrings) extractString(f *ast.File, fset *token.FileSet) error 
 			for _, expr := range x.Results {
 				es.processEnforcedFunc(expr, fset)
 			}
+		case ast.Decl:
+			if gen, ok := x.(*ast.GenDecl); ok {
+				for _, spec := range gen.Specs {
+					if valSpec, ok := spec.(*ast.ValueSpec); ok {
+						for _, expr := range valSpec.Values {
+							es.processEnforcedFunc(expr, fset)
+						}
+					}
+				}
+			}
 		case *ast.BasicLit:
 			if shouldProcessBasicLit {
 				es.processBasicLit(x, n, fset, false)

--- a/cmds/verify_strings.go
+++ b/cmds/verify_strings.go
@@ -243,7 +243,7 @@ func (vs *verifyStrings) verify(inputFilename string, targetFilename string) err
 			return err
 		}
 		vs.Println("i18n4go: generated diff file:", diffFilename)
-		verficationError = fmt.Errorf("i18n4go: target file is missing i18n strings with IDs:\n%s", strings.Join(keysForI18nStringInfoMap(inputMap), "\n"))
+		verficationError = fmt.Errorf("i18n4go: target file is missing i18n strings with IDs: %s", strings.Join(keysForI18nStringInfoMap(inputMap), ","))
 	}
 
 	return verficationError

--- a/cmds/verify_strings.go
+++ b/cmds/verify_strings.go
@@ -243,7 +243,7 @@ func (vs *verifyStrings) verify(inputFilename string, targetFilename string) err
 			return err
 		}
 		vs.Println("i18n4go: generated diff file:", diffFilename)
-		verficationError = fmt.Errorf("i18n4go: target file is missing i18n strings with IDs: %s", strings.Join(keysForI18nStringInfoMap(inputMap), ","))
+		verficationError = fmt.Errorf("i18n4go: target file is missing i18n strings with IDs:\n%s", strings.Join(keysForI18nStringInfoMap(inputMap), "\n"))
 	}
 
 	return verficationError

--- a/common/cmd.go
+++ b/common/cmd.go
@@ -56,9 +56,9 @@ type StringInfo struct {
 }
 
 type ExcludedStrings struct {
-	ExcludedStrings 	[]string `json:"excludedStrings"`
-	ExcludedLines   	[]string `json:"excludedLines"`
-	ExcludedRegexps 	[]string `json:"excludedRegexps"`
+	ExcludedStrings     []string `json:"excludedStrings"`
+	ExcludedLines       []string `json:"excludedLines"`
+	ExcludedRegexps     []string `json:"excludedRegexps"`
 	ExcludedFileRegexps []string `json:"excludedFileRegexps"`
 }
 

--- a/common/cmd.go
+++ b/common/cmd.go
@@ -60,6 +60,7 @@ type ExcludedStrings struct {
 	ExcludedLines       []string `json:"excludedLines"`
 	ExcludedRegexps     []string `json:"excludedRegexps"`
 	ExcludedFileRegexps []string `json:"excludedFileRegexps"`
+	EnforcedFuncs       []string `json:"enforcedFuncs"`
 }
 
 type PrinterInterface interface {

--- a/i18n4go/i18n4go.go
+++ b/i18n4go/i18n4go.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Liam-Williams/i18n4go/common"
 )
 
-const VERSION = "v0.2.4"
+const VERSION = "v0.2.7"
 
 var options common.Options
 


### PR DESCRIPTION
The intention for SetMessage is to have the string always available to be localized.

Currently we have an issue in cases like below 
```go
e.Wrap(err, "ignore translation").SetMessage(ctx, "translate me")
```

I would like to exclude pkg e functions (NewError and Wrap) from being linted, but it is currently impossible to handle cases of method chaining since there's no way of "whitelisting" string tokens inside functions.

Tested locally with no noticeable performance cost